### PR TITLE
Support deploying when multiple backends are used

### DIFF
--- a/templates/mdbook_build.sh.j2
+++ b/templates/mdbook_build.sh.j2
@@ -33,10 +33,14 @@ build_site() {
 
     # build
     cd "$MDBOOK_SRC_PATH" || { echo >&2 "Could not cd into source subdir: ${MDBOOK_SRC_PATH}"; exit 2; }
+    rm -rf book/
     mdbook build
 
     # Deploy the site
-    rsync -a --delete book/ "$MDBOOK_SERVE_PATH"
+    MDBOOK_BUILD_PATH="book/"
+    [ -d "$MDBOOK_BUILD_PATH/html" ] && MDBOOK_BUILD_PATH="$MDBOOK_BUILD_PATH/html/"
+
+    rsync -a --delete "$MDBOOK_BUILD_PATH" "$MDBOOK_SERVE_PATH"
 
     # Fix the system permissions
     chmod og+rX "$MDBOOK_SERVE_PATH"


### PR DESCRIPTION
If no backend besides the HTML one is configured, mdbook builds the book
inside `book/`. If another backend is configured, even if it doesn't
run, the book is built inside `book/html/`. Given that changes in the
source can lead to the removal of some backend at some point in time,
this makes the deployment resistant to those changes.

Deleting the `book/` dir helps in avoiding leftover directories or files
affecting the deployment process.